### PR TITLE
Fix hero slow load

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -110,12 +110,14 @@
 
 	};
 
-	// Play initial animations on page load.
-		$window.on('load', function() {
-			window.setTimeout(function() {
-				$body.removeClass('is-preload');
-			}, 100);
-		});
+       // Play initial animations as soon as the DOM is ready so that
+       // the header becomes visible without waiting for heavy assets
+       // (like embedded videos) to finish loading.
+               $(function() {
+                       window.setTimeout(function() {
+                               $body.removeClass('is-preload');
+                       }, 100);
+               });
 
 	// Scrolly.
 		$('.scrolly').scrolly();


### PR DESCRIPTION
## Summary
- display header as soon as DOM is ready instead of waiting for videos to load

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842dc7af2588328b9b061796ae9e953