### PR TITLE
Atualiza imagem do retrato na página index-new

### DIFF
--- a/assets/css/index-new.css
+++ b/assets/css/index-new.css
@@ -145,7 +145,7 @@ h3 {
 .hero-media img {
         width: 100%;
         max-width: 320px;
-        border-radius: 50%;
+        border-radius: 0;
         display: block;
         margin: 0 auto;
         box-shadow: 0 2rem 4rem rgba(10, 13, 32, 0.45);
@@ -395,7 +395,7 @@ h3 {
 .brand img {
         width: 54px;
         height: 54px;
-        border-radius: 50%;
+        border-radius: 0;
         object-fit: cover;
         box-shadow: 0 1rem 2rem rgba(5, 7, 18, 0.4);
 }

--- a/index-new.html
+++ b/index-new.html
@@ -15,7 +15,7 @@
     <header id="site-header" class="stellar-header" role="banner">
       <div class="header-inner">
         <a class="brand" href="#intro">
-          <img src="images/matheus-haddad-pb.png" alt="Retrato de Matheus Haddad" />
+          <img src="images/matheus-haddad-2025.jpg" alt="Retrato de Matheus Haddad" />
           <span>
             <strong>Matheus Haddad</strong>
             <span class="tagline">Consultor em estilos de gestão orgânicos</span>
@@ -41,7 +41,7 @@
       <section id="intro" class="section hero">
         <div class="hero-grid">
           <div class="hero-media">
-            <img src="images/matheus-haddad-pb.png" alt="Matheus Haddad" />
+            <img src="images/matheus-haddad-2025.jpg" alt="Matheus Haddad" />
           </div>
           <div class="hero-content">
             <h1>Matheus Haddad</h1>


### PR DESCRIPTION
## Summary
- troca a imagem antiga pelas novas fotos `matheus-haddad-2025.jpg` no cabeçalho e na seção hero
- remove o raio de borda que gerava o recorte circular, exibindo as fotos em formato retangular

## Testing
- não aplicável


------
https://chatgpt.com/codex/tasks/task_e_68d28a578dbc83288f2d38c10dff3528