### PR TITLE
Atualiza destaque inicial e estilos

### DIFF
--- a/assets/css/index-new.css
+++ b/assets/css/index-new.css
@@ -142,6 +142,10 @@ h3 {
         gap: clamp(2rem, 5vw, 4rem);
 }
 
+.hero-media {
+        align-self: start;
+}
+
 .hero-media img {
         width: 100%;
         max-width: 320px;
@@ -221,7 +225,7 @@ h3 {
 
 .company-card img {
         width: 100%;
-        height: 72px;
+        height: 200px;
         object-fit: contain;
         border-radius: 0.75rem;
         background: #fff;

--- a/index-new.html
+++ b/index-new.html
@@ -45,11 +45,8 @@
           </div>
           <div class="hero-content">
             <h1>Matheus Haddad</h1>
-            <p class="tagline">Consultor em estilos de gestão ágeis, horizontais, distribuídos e orgânicos.</p>
-            <p>Empreendedor, empresário e crítico das abordagens tradicionais de gestão, destaca-se pelo seu pensamento inovador nos negócios e pela sua visão diferente do mundo do trabalho.</p>
-            <p>Fundador de empresas nas áreas de tecnologia, financeira e educacional, adotou em todas elas um estilo de gestão orgânico e centrado nas pessoas.</p>
-            <p>Possui mais de 15 anos de experiência em autogestão e criou práticas e ferramentas para fomentar o trabalho em equipe e ajudar no desenvolvimento da autonomia organizacional.</p>
-            <p>Acredita que comunicação transparente e a colaboração entre as pessoas ajuda a criar um ambiente de trabalho mais saudável e produtivo.</p>
+            <p class="tagline">Empresário, empreendedor serial e pesquisador de novas abordagens de gestão.</p>
+            <p>Atua há mais de 15 anos com desenvolvimento de negócios, tecnologia e transformação organizacional. Graduado em Ciência da Computação pela UNIFENAS, Mestre em Inteligência Artificial pelo Centro Universitário da FEI e MBA em Gestão Empresarial pela Fundação Getúlio Vargas. Como consultor e palestrante, já apoiou diversas organizações e times na criação de culturas mais saudáveis e alinhadas com os princípios do trabalho moderno.</p>
             <ul class="social-links">
               <li>
                 <a href="https://x.com/mhaddad" class="icon brands fa-twitter" aria-label="X (antigo Twitter)"><span class="sr-only">X (antigo Twitter)</span></a>


### PR DESCRIPTION
## Summary
- ajusta o destaque inicial com o novo texto de apresentação de Matheus
- alinha o bloco de mídia do herói ao topo do grid
- aumenta a altura das imagens dos cartões de empresas para 200px

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d28f04dd3c83288c5b39ab9a06e0f0